### PR TITLE
LGA-3053 Add in Sonarcloud Scanning to Civil Case API

### DIFF
--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -14,7 +14,9 @@ jobs:
   static-analysis:
     name: Static Analysis
     uses: ./.github/workflows/static-analysis.yml
-
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      
   test:
     name: Test
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -11,6 +11,8 @@ jobs:
   static-analysis:
     name: Static Analysis
     uses: ./.github/workflows/static-analysis.yml
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   test:
     name: Test

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,6 +1,9 @@
 name: Static Analysis
 on:
   workflow_call:
+    secrets:
+      SONAR_TOKEN:
+        required: true
 
 jobs:
   lint:
@@ -12,3 +15,20 @@ jobs:
         with:
           args: check --output-format=github
           src: './src'
+
+  sonarcloud:
+    name: Sonar cloud
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Number of commits to fetch. 0 indicates all history for all branches and tags.
+          # Default: 1
+          fetch-depth: 0
+      - uses: sonarsource/sonarcloud-github-action@master
+        with:
+          args: >
+            -Dsonar.python.version=3.12
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.organization=ministryofjustice
+sonar.projectKey=ministryofjustice_laa-civil-case-api
+
+# relative paths to source directories. More details and properties are described
+# in https://sonarcloud.io/documentation/project-administration/narrowing-the-focus/
+sonar.sources=src


### PR DESCRIPTION
What does this pull request do?
Adds in sonarcloud scanning to the Civil Case API. This follows the same format as the Access application.

Any other changes that would benefit highlighting?
Intentionally left blank.

Checklist
https://dsdmoj.atlassian.net/browse/LGA-3053