### PR TITLE
Bug/Use title for checking if PR was created by Snyk.

### DIFF
--- a/.github/workflows/gajira.yml
+++ b/.github/workflows/gajira.yml
@@ -8,7 +8,7 @@ jobs:
   gajira:
     name: Raise Jira Issue
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.pull_request.labels, 'snyk') }}
+    if: ${{ contains(github.event.pull_request.title, 'snyk') }}
     steps:
     - name: Login
       uses: atlassian/gajira-login@master


### PR DESCRIPTION
## What does this pull request do?

Fixes the issue where labels were being rather than the PR title to check if the PR was created by Snyk.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"