### PR TITLE
LGA-3268: Add case notes model

### DIFF
--- a/app/db/migrations/env.py
+++ b/app/db/migrations/env.py
@@ -1,5 +1,9 @@
 from logging.config import fileConfig
 
+# This is used to auto generate migrations for Postgres Enum types. Natively Alembic does not support altering
+# Enum types after creation without manually writing the migrations.
+import alembic_postgresql_enum  # noqa: F401
+
 from app.db import db_url
 
 # Imports all the models so Alembic knows what to generate migrations for.
@@ -72,7 +76,12 @@ def run_migrations_online() -> None:
     )
 
     with connectable.connect() as connection:
-        context.configure(connection=connection, target_metadata=target_metadata)
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            compare_type=True,
+            compare_server_default=True,
+        )
 
         with context.begin_transaction():
             context.run_migrations()

--- a/app/db/migrations/versions/48b9cef7f8a2_add_case_model.py
+++ b/app/db/migrations/versions/48b9cef7f8a2_add_case_model.py
@@ -2,33 +2,47 @@
 
 Revision ID: 48b9cef7f8a2
 Revises: 2a0a7fdef0f6
-Create Date: 2024-09-06 13:37:27.178152
+Create Date: 2024-10-03 22:49:21.553826
 
 """
 
+from typing import Sequence, Union
+
 from alembic import op
 import sqlalchemy as sa
-
+from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision: str = "48b9cef7f8a2"
-down_revision = "2a0a7fdef0f6"
-branch_labels = None
-depends_on = None
+down_revision: Union[str, None] = "2a0a7fdef0f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
+    sa.Enum("CCQ", "CLA", name="casetypes").create(op.get_bind())
     op.create_table(
         "cases",
         sa.Column("created_at", sa.DateTime(), nullable=False),
         sa.Column("updated_at", sa.DateTime(), nullable=False),
         sa.Column("id", sa.Uuid(), nullable=False),
-        sa.Column("case_type", sa.Enum("CCQ", "CLA", name="casetypes"), nullable=False),
+        sa.Column(
+            "case_type",
+            postgresql.ENUM("CCQ", "CLA", name="casetypes", create_type=False),
+            nullable=False,
+        ),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index(op.f("ix_cases_case_type"), "cases", ["case_type"], unique=False)
+    sa.Enum(
+        "asylum", "crime", "debt", "family", "housing", "welfare", name="category"
+    ).drop(op.get_bind())
 
 
 def downgrade() -> None:
+    sa.Enum(
+        "asylum", "crime", "debt", "family", "housing", "welfare", name="category"
+    ).create(op.get_bind())
     op.drop_index(op.f("ix_cases_case_type"), table_name="cases")
     op.drop_table("cases")
+    sa.Enum("CCQ", "CLA", name="casetypes").drop(op.get_bind())

--- a/app/db/migrations/versions/dae1c53bd08c_add_case_notes.py
+++ b/app/db/migrations/versions/dae1c53bd08c_add_case_notes.py
@@ -1,0 +1,63 @@
+"""Add case notes
+
+Revision ID: dae1c53bd08c
+Revises: 48b9cef7f8a2
+Create Date: 2024-10-03 22:52:44.677974
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "dae1c53bd08c"
+down_revision: Union[str, None] = "48b9cef7f8a2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    sa.Enum(
+        "personal", "provider", "caseworker", "operator", "other", name="notetype"
+    ).create(op.get_bind())
+    op.create_table(
+        "case_notes",
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column(
+            "note_type",
+            postgresql.ENUM(
+                "personal",
+                "provider",
+                "caseworker",
+                "operator",
+                "other",
+                name="notetype",
+                create_type=False,
+            ),
+            nullable=False,
+        ),
+        sa.Column("content", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("case_id", sa.Uuid(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["case_id"],
+            ["cases.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_case_notes_note_type"), "case_notes", ["note_type"], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_case_notes_note_type"), table_name="case_notes")
+    op.drop_table("case_notes")
+    sa.Enum(
+        "personal", "provider", "caseworker", "operator", "other", name="notetype"
+    ).drop(op.get_bind())

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,2 +1,4 @@
+#  All models which exist in the database should be imported here.
 from .cases import Case  # noqa: F401
 from .users import User  # noqa: F401
+from .case_notes import CaseNote  # noqa: F401

--- a/app/models/case_notes.py
+++ b/app/models/case_notes.py
@@ -24,3 +24,10 @@ class CaseNote(BaseCaseNote, TableModelMixin, table=True):
     # This allows for linking the notes back to the case, this allows us to address case notes directly by using
     # the `Case.notes` syntax, rather than searching for each note using its ID.
     case: "Case" = Relationship(back_populates="notes")  # noqa: F821
+
+    def __str__(self):
+        return (
+            f"{self.note_type.value} note\n"
+            f"Attached to case ID: {self.case_id}"
+            f"{self.content}"
+        )

--- a/app/models/case_notes.py
+++ b/app/models/case_notes.py
@@ -19,9 +19,8 @@ class BaseCaseNote(SQLModel):
 
 
 class CaseNote(BaseCaseNote, TableModelMixin, table=True):
-    """This allows for linking the notes back to the case, this allows us to address case notes directly by using
-    the `Case.notes` syntax, rather than searching for each note using its ID.
-    """
-
     __tablename__ = "case_notes"
+
+    # This allows for linking the notes back to the case, this allows us to address case notes directly by using
+    # the `Case.notes` syntax, rather than searching for each note using its ID.
     case: "Case" = Relationship(back_populates="notes")  # noqa: F821

--- a/app/models/case_notes.py
+++ b/app/models/case_notes.py
@@ -23,4 +23,5 @@ class CaseNote(BaseCaseNote, TableModelMixin, table=True):
     the `Case.notes` syntax, rather than searching for each note using its ID.
     """
 
+    __tablename__ = "case_notes"
     case: "Case" = Relationship(back_populates="notes")  # noqa: F821

--- a/app/models/case_notes.py
+++ b/app/models/case_notes.py
@@ -1,0 +1,26 @@
+from sqlmodel import Field, SQLModel, Relationship
+from app.models.base import TableModelMixin
+from enum import Enum
+from uuid import UUID
+
+
+class NoteType(str, Enum):
+    personal = "Personal"
+    provider = "Provider"
+    caseworker = "Caseworker"
+    operator = "Operator"
+    other = "Other"
+
+
+class BaseCaseNote(SQLModel):
+    note_type: NoteType = Field(index=True, default=NoteType.other)
+    content: str = Field(default="")
+    case_id: UUID = Field(foreign_key="cases.id")
+
+
+class CaseNote(BaseCaseNote, TableModelMixin, table=True):
+    """This allows for linking the notes back to the case, this allows us to address case notes directly by using
+    the `Case.notes` syntax, rather than searching for each note using its ID.
+    """
+
+    case: "Case" = Relationship(back_populates="notes")  # noqa: F821

--- a/app/models/cases.py
+++ b/app/models/cases.py
@@ -1,6 +1,8 @@
-from sqlmodel import Field, SQLModel
+from sqlmodel import Field, SQLModel, Relationship
+from typing import List
 from app.models.base import TableModelMixin
 from app.models.case_types import CaseTypes
+from app.models.case_notes import CaseNote
 
 
 class BaseCase(SQLModel):
@@ -10,7 +12,8 @@ class BaseCase(SQLModel):
 
 
 class Case(BaseCase, TableModelMixin, table=True):
-    pass
+    # Cascade delete ensures all related notes are deleted when the attached case is deleted.
+    notes: List[CaseNote] = Relationship(back_populates="case", cascade_delete=True)
 
 
 class CaseRequest(BaseCase):

--- a/tests/case_notes/test_case_notes.py
+++ b/tests/case_notes/test_case_notes.py
@@ -53,6 +53,7 @@ def test_updated_at(session: Session):
 
 
 def test_cascade_delete(session: Session):
+    """If a case is deleted all notes attached to said case should also be deleted."""
     case = Case(case_type=CaseTypes.CLA)
     note = CaseNote(case_id=case.id)
 
@@ -86,3 +87,16 @@ def test_cascade_delete_multiple_notes(session: Session):
 
     # After the case is deleted the attached notes are also removed
     assert len(session.exec(select(CaseNote)).all()) == 0
+
+
+def test_reverse_cascade_delete(session: Session):
+    """If a note is deleted we want to make sure the attached case is not deleted."""
+    case = Case(case_type=CaseTypes.CLA)
+    note = CaseNote(case_id=case.id)
+    session.add(case)
+    session.add(note)
+    session.commit()
+    session.delete(note)
+    session.commit()
+    assert session.exec(select(Case)).all() == [case]
+    assert session.exec(select(CaseNote)).all() == []

--- a/tests/case_notes/test_case_notes.py
+++ b/tests/case_notes/test_case_notes.py
@@ -1,0 +1,52 @@
+from app.models.cases import Case
+from app.models.case_notes import CaseNote, NoteType
+import uuid
+from sqlmodel import Session
+from app.models.case_types import CaseTypes
+from datetime import datetime, UTC
+
+
+def test_attach_note(session: Session):
+    case = Case(case_type=CaseTypes.CLA)
+    note = CaseNote(case_id=case.id, content="Hello world", note_type=NoteType.provider)
+    session.add(case)
+    session.add(note)
+    session.commit()
+    assert len(case.notes) == 1
+    assert case.notes[0].content == "Hello world"
+    assert note.note_type == "Provider"
+
+
+def test_empty_note(session: Session):
+    case = Case(case_type=CaseTypes.CLA)
+    note = CaseNote(case_id=case.id)
+    session.add(case)
+    session.add(note)
+    session.commit()
+    assert len(case.notes) == 1
+    assert case.notes[0].content == ""
+
+
+def test_default_note_type():
+    assert CaseNote(case_id=uuid.uuid4()).note_type == "Other"
+
+
+def test_created_at():
+    before = datetime.now(UTC)
+    note = CaseNote(case_id=uuid.uuid4())
+    after = datetime.now(UTC)
+    assert before <= note.created_at <= after
+
+
+def test_updated_at(session: Session):
+    note = CaseNote(case_id=uuid.uuid4(), content="Created")
+    session.add(note)
+    session.commit()
+    after_creation = datetime.now(UTC)
+
+    note.content = "Updated"
+    session.add(note)
+    session.commit()
+
+    assert note.updated_at.replace(tzinfo=UTC) > after_creation
+    assert note.content == "Updated"

--- a/tests/case_notes/test_case_notes.py
+++ b/tests/case_notes/test_case_notes.py
@@ -100,3 +100,15 @@ def test_reverse_cascade_delete(session: Session):
     session.commit()
     assert session.exec(select(Case)).all() == [case]
     assert session.exec(select(CaseNote)).all() == []
+
+
+def test_case_notes_string_format():
+    provider_note = CaseNote(note_type=NoteType.provider, case_id=uuid.uuid4())
+    assert "Provider note" in str(provider_note)
+
+    operator_note = CaseNote(note_type=NoteType.operator, case_id=uuid.uuid4())
+    assert "Operator note" in str(operator_note)
+
+    case_id = uuid.uuid4()
+    note = CaseNote(case_id=case_id)
+    assert f"Attached to case ID: {case_id}" in str(note)


### PR DESCRIPTION
## What does this pull request do?

- Adds Case Notes model
- Adds notes backlink relationship to Case model, this allows us to access a list of attached case notes using `Case.notes`

## Any other changes that would benefit highlighting?

- Improves autogenerating Postgres Enum types migration

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"