### PR TITLE
Use alembic Postgres enums

### DIFF
--- a/app/db/migrations/versions/48b9cef7f8a2_add_case_model.py
+++ b/app/db/migrations/versions/48b9cef7f8a2_add_case_model.py
@@ -34,15 +34,9 @@ def upgrade() -> None:
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index(op.f("ix_cases_case_type"), "cases", ["case_type"], unique=False)
-    sa.Enum(
-        "asylum", "crime", "debt", "family", "housing", "welfare", name="category"
-    ).drop(op.get_bind())
 
 
 def downgrade() -> None:
-    sa.Enum(
-        "asylum", "crime", "debt", "family", "housing", "welfare", name="category"
-    ).create(op.get_bind())
     op.drop_index(op.f("ix_cases_case_type"), table_name="cases")
     op.drop_table("cases")
     sa.Enum("CCQ", "CLA", name="casetypes").drop(op.get_bind())

--- a/requirements/generated/requirements-development.txt
+++ b/requirements/generated/requirements-development.txt
@@ -5,8 +5,10 @@
 #    pip-compile --output-file=requirements/generated/requirements-development.txt requirements/source/requirements-development.in
 #
 alembic==1.13.2
-    # via -r requirements/source/requirements-base.in
-alembic-autogenerate-enums==0.1.2
+    # via
+    #   -r requirements/source/requirements-base.in
+    #   alembic-postgresql-enum
+alembic-postgresql-enum==1.3.0
     # via -r requirements/source/requirements-base.in
 annotated-types==0.7.0
     # via pydantic
@@ -121,6 +123,7 @@ sqlalchemy[asyncio]==2.0.31
     # via
     #   -r requirements/source/requirements-base.in
     #   alembic
+    #   alembic-postgresql-enum
     #   sqlmodel
 sqlmodel==0.0.21
     # via -r requirements/source/requirements-base.in

--- a/requirements/generated/requirements-linting.txt
+++ b/requirements/generated/requirements-linting.txt
@@ -5,8 +5,10 @@
 #    pip-compile --output-file=requirements/generated/requirements-linting.txt requirements/source/requirements-linting.in
 #
 alembic==1.13.2
-    # via -r requirements/source/requirements-base.in
-alembic-autogenerate-enums==0.1.2
+    # via
+    #   -r requirements/source/requirements-base.in
+    #   alembic-postgresql-enum
+alembic-postgresql-enum==1.3.0
     # via -r requirements/source/requirements-base.in
 annotated-types==0.7.0
     # via pydantic
@@ -107,6 +109,7 @@ sqlalchemy[asyncio]==2.0.31
     # via
     #   -r requirements/source/requirements-base.in
     #   alembic
+    #   alembic-postgresql-enum
     #   sqlmodel
 sqlmodel==0.0.21
     # via -r requirements/source/requirements-base.in

--- a/requirements/generated/requirements-production.txt
+++ b/requirements/generated/requirements-production.txt
@@ -5,8 +5,10 @@
 #    pip-compile --output-file=requirements/generated/requirements-production.txt requirements/source/requirements-production.in
 #
 alembic==1.13.2
-    # via -r requirements/source/requirements-base.in
-alembic-autogenerate-enums==0.1.2
+    # via
+    #   -r requirements/source/requirements-base.in
+    #   alembic-postgresql-enum
+alembic-postgresql-enum==1.3.0
     # via -r requirements/source/requirements-base.in
 annotated-types==0.7.0
     # via pydantic
@@ -105,6 +107,7 @@ sqlalchemy[asyncio]==2.0.31
     # via
     #   -r requirements/source/requirements-base.in
     #   alembic
+    #   alembic-postgresql-enum
     #   sqlmodel
 sqlmodel==0.0.21
     # via -r requirements/source/requirements-base.in

--- a/requirements/generated/requirements-testing.txt
+++ b/requirements/generated/requirements-testing.txt
@@ -5,8 +5,10 @@
 #    pip-compile --output-file=requirements/generated/requirements-testing.txt requirements/source/requirements-testing.in
 #
 alembic==1.13.2
-    # via -r requirements/source/requirements-base.in
-alembic-autogenerate-enums==0.1.2
+    # via
+    #   -r requirements/source/requirements-base.in
+    #   alembic-postgresql-enum
+alembic-postgresql-enum==1.3.0
     # via -r requirements/source/requirements-base.in
 annotated-types==0.7.0
     # via pydantic
@@ -119,6 +121,7 @@ sqlalchemy[asyncio]==2.0.31
     # via
     #   -r requirements/source/requirements-base.in
     #   alembic
+    #   alembic-postgresql-enum
     #   sqlmodel
 sqlmodel==0.0.21
     # via -r requirements/source/requirements-base.in

--- a/requirements/source/requirements-base.in
+++ b/requirements/source/requirements-base.in
@@ -3,7 +3,7 @@ typing-extensions>=4.0
 sqlalchemy[asyncio]
 sqlmodel
 alembic
-alembic_autogenerate_enums
+alembic-postgresql-enum>=1.3.0
 sentry-sdk[fastapi]
 psycopg2-binary
 pyjwt


### PR DESCRIPTION
## What does this pull request do?

- Make PostgreSQL Enums a requirement for Alembic migrations
- Fixes a faulty Alembic migration which was dropping a type that doesn't exist

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"