### PR TITLE
Create request/response models

### DIFF
--- a/app/db/migrations/versions/117a6ec2770b_case_tracker.py
+++ b/app/db/migrations/versions/117a6ec2770b_case_tracker.py
@@ -15,7 +15,7 @@ import sqlmodel
 
 # revision identifiers, used by Alembic.
 revision: str = "117a6ec2770b"
-down_revision: Union[str, None] = "da58faadfe41"
+down_revision: Union[str, None] = "e82379668dff"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/app/db/migrations/versions/e82379668dff_eligibility_outcomes.py
+++ b/app/db/migrations/versions/e82379668dff_eligibility_outcomes.py
@@ -14,7 +14,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision: str = "e82379668dff"
-down_revision: Union[str, None] = "da58faadfe41"
+down_revision: Union[str, None] = "dc7b04aafeff"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/app/models/base.py
+++ b/app/models/base.py
@@ -1,4 +1,6 @@
 import uuid
+from typing import List
+
 from sqlalchemy.orm import declared_attr
 from sqlmodel import Field, SQLModel
 from datetime import datetime, UTC
@@ -53,11 +55,11 @@ class BaseResponse(TableModelMixin):
 
 class BaseRequest(BaseModel):
     class Meta:
-        related_fields = {}
-        model = None
+        related_fields: List[str] = []
+        model: BaseModel
 
     @property
-    def model(self):
+    def model(self) -> BaseModel:
         if not self.Meta.model:
             raise NotImplementedError(
                 "Either set the Meta.model property or override the get_model() method."
@@ -65,10 +67,10 @@ class BaseRequest(BaseModel):
         return self.Meta.model
 
     @property
-    def related_fields(self):
+    def related_fields(self) -> List[str]:
         return self.Meta.related_fields
 
-    def translate(self):
+    def translate(self) -> dict:
         """Convert a dump of request to a dict that can easily be used to create an instance of a model"""
         data = self.model_dump()
         related_fields_names = self.related_fields
@@ -81,7 +83,7 @@ class BaseRequest(BaseModel):
                 fields[field_name] = field_value
         return {**fields, **self._translate_related_fields(related_fields_data)}
 
-    def _translate_related_fields(self, fields):
+    def _translate_related_fields(self, fields) -> dict:
         """Convert related fields from a dict to an instance of their declared model"""
         instances = {}
         for field_name, field_value in fields.items():

--- a/app/models/base.py
+++ b/app/models/base.py
@@ -81,7 +81,14 @@ class BaseRequest(BaseModel):
         return related_fields
 
     def translate(self) -> dict:
-        """Convert a dump of request to a dict that can easily be used to create an instance of a model"""
+        """
+        Convert a dump of request to a dict that can easily be used to create an instance of a model
+
+        This method currently only translates relationships that are two levels deep i.e Case.person
+        and not Case.person.income
+
+        Todo: Allow deeper level of nested fields to be translated
+        """
         data = self.model_dump()
         related_fields_names = self.related_fields
         related_fields_data = {}

--- a/app/models/base.py
+++ b/app/models/base.py
@@ -1,8 +1,12 @@
+import uuid
 from sqlalchemy.orm import declared_attr
 from sqlmodel import Field, SQLModel
 from datetime import datetime, UTC
-from uuid import UUID, uuid4
 from pydantic import BaseModel
+
+
+def generate_id() -> uuid.UUID:
+    return uuid.uuid4()
 
 
 class TimestampMixin(SQLModel):
@@ -28,7 +32,7 @@ class TableModelMixin(TimestampMixin):
     """Mixin adding a UUID4 ID and Timestamps to child models.
     All models which exist in the database should inherit from this mixin"""
 
-    id: UUID = Field(default_factory=uuid4, primary_key=True)
+    id: uuid.UUID = Field(default_factory=generate_id, primary_key=True)
 
     @declared_attr
     def __tablename__(self) -> str:

--- a/app/models/base.py
+++ b/app/models/base.py
@@ -7,6 +7,7 @@ from sqlalchemy.inspection import inspect
 from sqlmodel import Field, SQLModel
 from datetime import datetime, UTC
 from pydantic import BaseModel
+from pydantic.config import ConfigDict
 
 
 def generate_id() -> uuid.UUID:
@@ -52,6 +53,7 @@ class TableModelMixin(TimestampMixin):
 
 
 class BaseResponse(TableModelMixin):
+    model_config = ConfigDict(from_attributes=True)
     pass
 
 

--- a/app/models/base.py
+++ b/app/models/base.py
@@ -56,20 +56,22 @@ class BaseRequest(BaseModel):
         related_fields = {}
         model = None
 
-    def get_model(self):
+    @property
+    def model(self):
         if not self.Meta.model:
             raise NotImplementedError(
                 "Either set the Meta.model property or override the get_model() method."
             )
         return self.Meta.model
 
-    def get_related_fields(self):
+    @property
+    def related_fields(self):
         return self.Meta.related_fields
 
     def translate(self):
         """Convert a dump of request to a dict that can easily be used to create an instance of a model"""
         data = self.model_dump()
-        related_fields_names = self.get_related_fields()
+        related_fields_names = self.related_fields
         related_fields_data = {}
         fields = {}
         for field_name, field_value in data.items():
@@ -87,9 +89,9 @@ class BaseRequest(BaseModel):
             if not field:
                 continue
             if isinstance(field, list):
-                model = field[0].get_model()
+                model = field[0].model
             else:
-                model = field.get_model()
+                model = field.model
 
             if isinstance(field_value, list):
                 instances[field_name] = [model(**value) for value in field_value]

--- a/app/models/case_notes.py
+++ b/app/models/case_notes.py
@@ -1,5 +1,5 @@
 from sqlmodel import Field, Relationship
-from app.models.base import TableModelMixin, BaseRequest
+from app.models.base import TableModelMixin, BaseRequest, BaseResponse
 from enum import Enum
 from uuid import UUID
 
@@ -12,10 +12,13 @@ class NoteType(str, Enum):
     other = "Other"
 
 
-class CaseNote(TableModelMixin, table=True):
-    __tablename__ = "case_notes"
+class BaseCaseNote:
     note_type: NoteType = Field(index=True, default=NoteType.other)
     content: str = Field(default="")
+
+
+class CaseNote(BaseCaseNote, TableModelMixin, table=True):
+    __tablename__ = "case_notes"
     case_id: UUID = Field(foreign_key="cases.id")
     # This allows for linking the notes back to the case, this allows us to address case notes directly by using
     # the `Case.notes` syntax, rather than searching for each note using its ID.
@@ -29,9 +32,10 @@ class CaseNote(TableModelMixin, table=True):
         )
 
 
-class CaseNotesRequest(BaseRequest):
-    note_type: NoteType
-    content: str
-
-    class Meta:
+class CaseNotesRequest(BaseCaseNote, BaseRequest):
+    class Meta(BaseRequest.Meta):
         model = CaseNote
+
+
+class CaseNotesResponse(BaseCaseNote, BaseResponse):
+    pass

--- a/app/models/case_notes.py
+++ b/app/models/case_notes.py
@@ -1,5 +1,5 @@
-from sqlmodel import Field, SQLModel, Relationship
-from app.models.base import TableModelMixin
+from sqlmodel import Field, Relationship
+from app.models.base import TableModelMixin, BaseRequest
 from enum import Enum
 from uuid import UUID
 
@@ -12,15 +12,11 @@ class NoteType(str, Enum):
     other = "Other"
 
 
-class BaseCaseNote(SQLModel):
+class CaseNote(TableModelMixin, table=True):
+    __tablename__ = "case_notes"
     note_type: NoteType = Field(index=True, default=NoteType.other)
     content: str = Field(default="")
     case_id: UUID = Field(foreign_key="cases.id")
-
-
-class CaseNote(BaseCaseNote, TableModelMixin, table=True):
-    __tablename__ = "case_notes"
-
     # This allows for linking the notes back to the case, this allows us to address case notes directly by using
     # the `Case.notes` syntax, rather than searching for each note using its ID.
     case: "Case" = Relationship(back_populates="notes")  # noqa: F821
@@ -31,3 +27,11 @@ class CaseNote(BaseCaseNote, TableModelMixin, table=True):
             f"Attached to case ID: {self.case_id}"
             f"{self.content}"
         )
+
+
+class CaseNotesRequest(BaseRequest):
+    note_type: NoteType
+    content: str
+
+    class Meta:
+        model = CaseNote

--- a/app/models/case_tracker.py
+++ b/app/models/case_tracker.py
@@ -1,17 +1,26 @@
 from uuid import UUID
-from sqlmodel import SQLModel, Field, JSON, Relationship
-from app.models.base import TableModelMixin
+from sqlmodel import Field, JSON, Relationship
+from app.models.base import TableModelMixin, BaseRequest, BaseResponse
 
 
-class CaseTrackerBase(SQLModel):
-    case_id: UUID = Field(foreign_key="cases.id", index=True)
+class CaseTrackerBase:
     gtm_anon_id: str = Field()
     journey: dict = Field(sa_type=JSON)
 
 
 class CaseTracker(CaseTrackerBase, TableModelMixin, table=True):
     __tablename__ = "case_tracker"
+    case_id: UUID = Field(foreign_key="cases.id", index=True)
     # This allows for linking the case tracker back to the case, this allows us to address case tracker
     # directly by using the `Case.case_tracker` syntax, rather than searching for each eligibility outcome
     # using its ID.
     case: "Case" = Relationship(back_populates="case_tracker")  # noqa: F821
+
+
+class CaseTrackerRequest(CaseTrackerBase, BaseRequest):
+    class Meta:
+        model = CaseTracker
+
+
+class CaseTrackerResponse(CaseTrackerBase, BaseResponse):
+    pass

--- a/app/models/cases.py
+++ b/app/models/cases.py
@@ -31,7 +31,6 @@ class CaseRequest(BaseRequest):
     eligibility_outcomes: List[EligibilityOutcomesRequest] | None
 
     class Meta(BaseRequest.Meta):
-        related_fields = ["notes", "people", "case_tracker", "eligibility_outcomes"]
         model = Case
 
 

--- a/app/models/cases.py
+++ b/app/models/cases.py
@@ -1,20 +1,15 @@
-from sqlmodel import Field, SQLModel, Relationship
+from sqlmodel import Field, Relationship
 from typing import List
-from app.models.base import TableModelMixin
+from app.models.base import TableModelMixin, BaseRequest
 from app.models.types.case_types import CaseTypes
-from app.models.case_notes import CaseNote
+from app.models.case_notes import CaseNote, CaseNotesRequest
 from app.models.person import Person
 from app.models.case_tracker import CaseTracker
 from app.models.eligibility_outcomes import EligibilityOutcomes
 
 
-class BaseCase(SQLModel):
-    case_type: CaseTypes = Field(
-        index=True
-    )  # Which service is the case originally from
-
-
-class Case(BaseCase, TableModelMixin, table=True):
+class Case(TableModelMixin, table=True):
+    case_type: CaseTypes = Field(index=True)
     # Cascade delete ensures all related fields are deleted when the attached case is deleted.
     notes: List[CaseNote] = Relationship(back_populates="case", cascade_delete=True)
     people: List[Person] = Relationship(back_populates="case", cascade_delete=True)
@@ -24,7 +19,13 @@ class Case(BaseCase, TableModelMixin, table=True):
     )
 
 
-class CaseRequest(BaseCase):
-    """Request model used to create a new case"""
+class CaseRequest(BaseRequest):
+    case_type: CaseTypes
+    notes: List[CaseNotesRequest] | None
+    # people: List[Person] | None
+    # case_tracker: CaseTracker | None
+    # eligibility_outcomes: List[EligibilityOutcomes] | None
 
-    pass
+    class Meta:
+        foreign_fields = ["notes"]
+        model = Case

--- a/app/models/cases.py
+++ b/app/models/cases.py
@@ -1,11 +1,15 @@
 from sqlmodel import Field, Relationship
 from typing import List
-from app.models.base import TableModelMixin, BaseRequest
+from app.models.base import TableModelMixin, BaseRequest, BaseResponse
 from app.models.types.case_types import CaseTypes
-from app.models.case_notes import CaseNote, CaseNotesRequest
-from app.models.person import Person
-from app.models.case_tracker import CaseTracker
-from app.models.eligibility_outcomes import EligibilityOutcomes
+from app.models.case_notes import CaseNote, CaseNotesRequest, CaseNotesResponse
+from app.models.person import Person, PersonRequest, PersonResponse
+from app.models.case_tracker import CaseTracker, CaseTrackerRequest, CaseTrackerResponse
+from app.models.eligibility_outcomes import (
+    EligibilityOutcomes,
+    EligibilityOutcomesRequest,
+    EligibilityOutcomesResponse,
+)
 
 
 class Case(TableModelMixin, table=True):
@@ -22,10 +26,20 @@ class Case(TableModelMixin, table=True):
 class CaseRequest(BaseRequest):
     case_type: CaseTypes
     notes: List[CaseNotesRequest] | None
-    # people: List[Person] | None
-    # case_tracker: CaseTracker | None
-    # eligibility_outcomes: List[EligibilityOutcomes] | None
+    people: List[PersonRequest] | None
+    case_tracker: CaseTrackerRequest | None
+    eligibility_outcomes: List[EligibilityOutcomesRequest] | None
 
-    class Meta:
-        foreign_fields = ["notes"]
+    class Meta(BaseRequest.Meta):
+        related_fields = ["notes", "people", "case_tracker", "eligibility_outcomes"]
         model = Case
+
+
+class CaseResponse(BaseResponse):
+    notes: List[CaseNotesResponse] | None
+    people: List[PersonResponse] | None
+    case_tracker: CaseTrackerResponse | None
+    eligibility_outcomes: List[EligibilityOutcomesResponse] | None
+
+    class Config:
+        orm_mode = True

--- a/app/models/cases.py
+++ b/app/models/cases.py
@@ -39,6 +39,3 @@ class CaseResponse(BaseResponse):
     people: List[PersonResponse] | None
     case_tracker: CaseTrackerResponse | None
     eligibility_outcomes: List[EligibilityOutcomesResponse] | None
-
-    class Config:
-        orm_mode = True

--- a/app/models/eligibility_outcomes.py
+++ b/app/models/eligibility_outcomes.py
@@ -1,7 +1,7 @@
 from uuid import UUID
 from enum import Enum
-from sqlmodel import SQLModel, Field, JSON, Relationship
-from app.models.base import TableModelMixin
+from sqlmodel import Field, JSON, Relationship
+from app.models.base import TableModelMixin, BaseRequest, BaseResponse
 
 
 class EligibilityType(str, Enum):
@@ -16,8 +16,7 @@ class EligibilityOutcomeType(str, Enum):
     UNKNOWN = "Unknown"
 
 
-class EligibilityOutcomesBase(SQLModel):
-    case_id: UUID = Field(foreign_key="cases.id", index=True)
+class EligibilityOutcomesBase:
     eligibility_type: EligibilityType = Field(index=True)
     outcome: EligibilityOutcomeType = Field(index=True)
     answers: dict = Field(sa_type=JSON)
@@ -25,7 +24,17 @@ class EligibilityOutcomesBase(SQLModel):
 
 class EligibilityOutcomes(EligibilityOutcomesBase, TableModelMixin, table=True):
     __tablename__ = "eligibility_outcomes"
+    case_id: UUID = Field(foreign_key="cases.id", index=True)
     # This allows for linking the eligibility outcome back to the case, this allows us to address eligibility outcome
     # directly by using the `Case.eligibility_outcome` syntax, rather than searching for each eligibility outcome
     # using its ID.
     case: "Case" = Relationship(back_populates="eligibility_outcomes")  # noqa: F821
+
+
+class EligibilityOutcomesRequest(EligibilityOutcomesBase, BaseRequest):
+    class Meta:
+        model = EligibilityOutcomes
+
+
+class EligibilityOutcomesResponse(EligibilityOutcomesBase, BaseResponse):
+    pass

--- a/app/models/person.py
+++ b/app/models/person.py
@@ -1,13 +1,12 @@
-from sqlmodel import Field, SQLModel, String, Relationship
-from app.models.base import TableModelMixin
+from sqlmodel import Field, String, Relationship
+from app.models.base import TableModelMixin, BaseRequest, BaseResponse
 from app.models.types.postcode import Postcode
 from app.models.types.phone_number import PhoneNumber
 from pydantic import EmailStr
 from uuid import UUID
 
 
-class BasePersonModel(SQLModel):
-    case_id: UUID = Field(foreign_key="cases.id", index=True)
+class BasePerson:
     name: str
     address: str | None
     phone_number: PhoneNumber | None = Field(default=None, sa_type=String)
@@ -15,7 +14,17 @@ class BasePersonModel(SQLModel):
     email: EmailStr | None = Field(sa_type=String)
 
 
-class Person(BasePersonModel, TableModelMixin, table=True):
+class Person(BasePerson, TableModelMixin, table=True):
+    case_id: UUID = Field(foreign_key="cases.id", index=True)
     # This allows for linking the person back to the case, this allows us to address persons directly by using
     # the `Case.person` syntax, rather than searching for each note using its ID.
     case: "Case" = Relationship(back_populates="people")  # noqa: F821
+
+
+class PersonRequest(BasePerson, BaseRequest):
+    class Meta(BaseRequest.Meta):
+        model = Person
+
+
+class PersonResponse(BasePerson, BaseResponse):
+    pass

--- a/app/routers/case_information.py
+++ b/app/routers/case_information.py
@@ -33,7 +33,8 @@ async def read_all_cases(session: Session = Depends(get_session)) -> Sequence[Ca
 
 @router.post("/", tags=["cases"], response_model=Case)
 def create_case(request: CaseRequest, session: Session = Depends(get_session)) -> Case:
-    case = Case(**request.dict())
+    data = request.translate()
+    case = Case(**data)
     session.add(case)
     session.commit()
     session.refresh(case)

--- a/app/routers/case_information.py
+++ b/app/routers/case_information.py
@@ -2,7 +2,7 @@ from typing import Sequence
 
 from fastapi import APIRouter, HTTPException, Depends
 
-from app.models.cases import CaseRequest, Case
+from app.models.cases import CaseRequest, Case, CaseResponse
 from sqlmodel import Session, select
 from app.db import get_session
 from app.auth.security import get_current_active_user
@@ -31,8 +31,8 @@ async def read_all_cases(session: Session = Depends(get_session)) -> Sequence[Ca
     return cases
 
 
-@router.post("/", tags=["cases"], response_model=Case)
-def create_case(request: CaseRequest, session: Session = Depends(get_session)) -> Case:
+@router.post("/", tags=["cases"], response_model=CaseResponse)
+def create_case(request: CaseRequest, session: Session = Depends(get_session)):
     data = request.translate()
     case = Case(**data)
     session.add(case)

--- a/tests/cases/test_case_request.py
+++ b/tests/cases/test_case_request.py
@@ -1,0 +1,46 @@
+import uuid
+from freezegun import freeze_time
+from unittest.mock import patch
+from app.models.cases import CaseRequest
+from app.models.case_notes import CaseNote
+from app.models.person import Person
+from app.models.case_tracker import CaseTracker
+from app.models.eligibility_outcomes import EligibilityOutcomes
+
+TEST_DATA = {
+    "case_type": "Check if your client qualifies for legal aid",
+    "notes": [{"note_type": "Other", "content": ""}],
+    "people": [
+        {
+            "name": "string",
+            "address": "string",
+            "phone_number": "0202 21212",
+            "postcode": "sw1 1aa",
+            "email": "user@example.com",
+        }
+    ],
+    "case_tracker": {"gtm_anon_id": "string", "journey": {}},
+    "eligibility_outcomes": [
+        {"eligibility_type": "CCQ", "outcome": "In scope", "answers": {}}
+    ],
+}
+
+
+@patch("app.models.base.uuid.uuid4")
+@freeze_time("2024-08-23 10:00:00")
+def test_case_request(mock_uuid):
+    mock_uuid.return_value = uuid.UUID("12345678-1234-5678-1234-567812345678")
+
+    case_request = CaseRequest(**TEST_DATA)
+    data = case_request.translate()
+    expected_result = {
+        "case_type": "Check if your client qualifies for legal aid",
+        "notes": [CaseNote(**TEST_DATA["notes"][0])],
+        "people": [Person(**TEST_DATA["people"][0])],
+        "case_tracker": CaseTracker(**TEST_DATA["case_tracker"]),
+        "eligibility_outcomes": [
+            EligibilityOutcomes(**TEST_DATA["eligibility_outcomes"][0])
+        ],
+    }
+
+    assert data == expected_result

--- a/tests/cases/test_case_request.py
+++ b/tests/cases/test_case_request.py
@@ -1,7 +1,8 @@
 import uuid
 from freezegun import freeze_time
 from unittest.mock import patch
-from app.models.cases import CaseRequest
+from sqlmodel import Session
+from app.models.cases import CaseRequest, Case
 from app.models.case_notes import CaseNote
 from app.models.person import Person
 from app.models.case_tracker import CaseTracker
@@ -28,7 +29,7 @@ TEST_DATA = {
 
 @patch("app.models.base.uuid.uuid4")
 @freeze_time("2024-08-23 10:00:00")
-def test_case_request(mock_uuid):
+def test_case_request(mock_uuid, session: Session):
     mock_uuid.return_value = uuid.UUID("12345678-1234-5678-1234-567812345678")
 
     case_request = CaseRequest(**TEST_DATA)
@@ -44,3 +45,6 @@ def test_case_request(mock_uuid):
     }
 
     assert data == expected_result
+    case = Case(**data)
+    session.add(case)
+    session.commit()


### PR DESCRIPTION
## What does this pull request do?

Create request and response models for each of our models

## Any other changes that would benefit highlighting?

Previously we were doing `case = Case(**request.dict())` to create a case from the user request. This was causing an issue when trying to save nested fields(i.e case.notes, case.people) as those nested fields were coming through as a dict rather than their respective types.

Also we were using the model types as the return type from the endpoint i.e`@router.post("/", tags=["cases"], response_model=Case)`. This was causing the issue with nested fields(i.e notes, people) not being returned in the response which is the expected framework behaviour.

We have now moved to using a separate class for the request and response fields to address the issue of the nested fields in the request and response.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"