### PR TITLE
update ruff-action to use supported version with SHA pinning

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -32,11 +32,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Lint
-        uses: chartboost/ruff-action@v1
+        uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3.6.1
         with:
           args: check --output-format=github
       - name: Format
-        uses: chartboost/ruff-action@v1
+        uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3.6.1
         with:
           args: format --check
 


### PR DESCRIPTION
## What does this pull request do?

Updates he ruff-action to use a supported version
updates to the latest version 3.6.1 and uses SHA pinning

https://mojdt.slack.com/archives/C7KCVJZSQ/p1774950836015289

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"